### PR TITLE
HW networks

### DIFF
--- a/kubernetes-networks/canary/canary-deploy.yaml
+++ b/kubernetes-networks/canary/canary-deploy.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: canary
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: meistuss/otus_intro:latest
+        volumeMounts:
+        - name: app
+          mountPath: /app
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        livenessProbe:
+          tcpSocket: { port: 8000 }
+      initContainers:
+      - name: init-myservice
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}

--- a/kubernetes-networks/canary/canary-ingress.yaml
+++ b/kubernetes-networks/canary/canary-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  namespace: canary
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: "canary"
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /web
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port: 
+              number: 8000

--- a/kubernetes-networks/canary/canary-ns.yaml
+++ b/kubernetes-networks/canary/canary-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: canary
+  name: canary

--- a/kubernetes-networks/canary/canary-svc-headless.yaml
+++ b/kubernetes-networks/canary/canary-svc-headless.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+  namespace: canary
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000

--- a/kubernetes-networks/coredns/tcp-dns.yaml
+++ b/kubernetes-networks/coredns/tcp-dns.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-dns
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: dns-sharing-key
+spec:
+  loadBalancerIP: 172.17.255.55
+  ports:
+  - port: 53
+    targetPort: 53
+    protocol: TCP
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer

--- a/kubernetes-networks/coredns/udp-dns.yaml
+++ b/kubernetes-networks/coredns/udp-dns.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: udp-dns
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: dns-sharing-key
+spec:
+  loadBalancerIP: 172.17.255.55
+  ports:
+  - port: 53
+    targetPort: 53
+    protocol: UDP
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer

--- a/kubernetes-networks/dashboard/ingress.yaml
+++ b/kubernetes-networks/dashboard/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-dashboard
+  namespace: kubernetes-dashboard
+  labels:
+    k8s-app: kubernetes-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^(/dashboard)$ $1/ redirect;
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /dashboard(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: kubernetes-dashboard
+            port:
+              number: 443

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - "172.17.255.1-172.17.255.255"

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,18 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+  - { name: http, port: 80, targetPort: http }
+  - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: meistuss/otus_intro:latest
+        volumeMounts:
+        - name: app
+          mountPath: /app
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        livenessProbe:
+          tcpSocket: { port: 8000 }
+      initContainers:
+      - name: init-myservice
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /web
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port: 
+              number: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - "Добавление проверок Pod"
 ```bash
 $ kubectl apply -f ./web-pod.yaml 
    pod/web created
 $ kubectl get pod/web
    NAME   READY   STATUS    RESTARTS   AGE
    web    0/1     Running   0          22s
 $ kubectl describe pod/web
 ...
    Conditions:
    Type              Status
    Initialized       True 
    Ready             False 
    ContainersReady   False 
    PodScheduled      True 
 ...
 Warning  Unhealthy  10s (x9 over 70s)  kubelet            Readiness probe failed: Get "http://172.17.0.3:80/index.html": dial tcp 172.17.0.3:80: connect: connection refused
 ```
 - "Создание Deployment"
 ```bash
 $ kubectl apply -f web-deploy.yaml
 $ kubectl describe deployment web
 ...
    Conditions:
    Type           Status  Reason
    ----           ------  ------
    Available      False   MinimumReplicasUnavailable
    Progressing    True    ReplicaSetUpdated
 ...
 # Увеличивавем replicas до 3, исправляем ReadnessProbe и применяем
 $ kubectl describe deployment web
    Conditions:
    Type           Status  Reason
    ----           ------  ------
    Available      True    MinimumReplicasAvailable
    Progressing    True    NewReplicaSetAvailable
    OldReplicaSets:  <none>
    NewReplicaSet:   web-7548bd6647 (3/3 replicas created)
 ```
 - "Создание Service"
 ```bash
 $ kubectl apply -f web-svc-cip.yaml
 $ kubectl get svc
    NAME          TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)   AGE
    kubernetes    ClusterIP   10.96.0.1     <none>        443/TCP   29m
    web-svc-cip   ClusterIP   10.97.56.61   <none>        80/TCP    7s
 ```
 - Установка MetalLB
 ```bash
 kubectl --namespace metallb-system get all
    NAME                              READY   STATUS    RESTARTS   AGE
    pod/controller-6fb5bff444-zxpd2   1/1     Running   0          15m
    pod/speaker-g96cg                 1/1     Running   0          15m

    NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                 AGE
    daemonset.apps/speaker   1         1         1       1            1           beta.kubernetes.io/os=linux   15m

    NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
    deployment.apps/controller   1/1     1            1           15m

    NAME                                    DESIRED   CURRENT   READY   AGE
    replicaset.apps/controller-6fb5bff444   1         1         1       15m
 kubectl -n metallb-system logs controller-6fb5bff444-zxpd2
 ...
 {"caller":"service.go:114","event":"ipAllocated","ip":"172.17.255.1","msg":"IP address assigned by controller","service":"default/web-svc-lb","ts...
 ...
 ```
  - DNS через MetalLB
 ```bash
$ kubectl get svc -n kube-system 
    NAME       TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                  AGE
    kube-dns   ClusterIP      10.96.0.10     <none>          53/UDP,53/TCP,9153/TCP   5d14h
    tcp-dns    LoadBalancer   10.106.64.96   172.17.255.55   53:31278/TCP             6m42s
    udp-dns    LoadBalancer   10.102.165.3   172.17.255.55   53:30528/UDP             5m55s
 ```
  - Создание Ingress
 Ingress контроллер установлен через helm
 ```bash
 helm upgrade --install ingress-nginx ingress-nginx \
  --repo https://kubernetes.github.io/ingress-nginx \
  --namespace ingress-nginx --create-namespace
 ```

## Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
